### PR TITLE
Adds `Colored Glass` tag to glass pieces.

### DIFF
--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBlack.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBlack.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -94,6 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
+    [Tag("Coloured Glass")]
     [LocDisplayName("Black Glass")]
     public partial class BlackGlassItem : BlockItem<BlackGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBlack.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBlack.cs
@@ -93,7 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [LocDisplayName("Black Glass")]
     public partial class BlackGlassItem : BlockItem<BlackGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBlue.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBlue.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -94,6 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
+    [Tag("Coloured Glass")]
     [LocDisplayName("Blue Glass")]
     public partial class BlueGlassItem : BlockItem<BlueGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBlue.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBlue.cs
@@ -93,7 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [LocDisplayName("Blue Glass")]
     public partial class BlueGlassItem : BlockItem<BlueGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBrown.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBrown.cs
@@ -93,7 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [LocDisplayName("Brown Glass")]
     public partial class BrownGlassItem : BlockItem<BrownGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBrown.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassBrown.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -94,6 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
+    [Tag("Coloured Glass")]
     [LocDisplayName("Brown Glass")]
     public partial class BrownGlassItem : BlockItem<BrownGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassGreen.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassGreen.cs
@@ -92,7 +92,7 @@ namespace Eco.EM.Building.Windows
     [Serialized]
     [MaxStackSize(20)]
     [Currency]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [Weight(10000)]
     [LocDisplayName("Green Glass")]
     public partial class GreenGlassItem : BlockItem<GreenGlassBlock>

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassGreen.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassGreen.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -93,6 +92,7 @@ namespace Eco.EM.Building.Windows
     [Serialized]
     [MaxStackSize(20)]
     [Currency]
+    [Tag("Coloured Glass")]
     [Weight(10000)]
     [LocDisplayName("Green Glass")]
     public partial class GreenGlassItem : BlockItem<GreenGlassBlock>

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassGrey.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassGrey.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -94,6 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
+    [Tag("Coloured Glass")]
     [LocDisplayName("Grey Glass")]
     public partial class GreyGlassItem : BlockItem<GreyGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassGrey.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassGrey.cs
@@ -93,7 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [LocDisplayName("Grey Glass")]
     public partial class GreyGlassItem : BlockItem<GreyGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassOrange.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassOrange.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -94,6 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
+    [Tag("Coloured Glass")]
     [LocDisplayName("Orange Glass")]
     public partial class OrangeGlassItem : BlockItem<OrangeGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassOrange.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassOrange.cs
@@ -93,7 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [LocDisplayName("Orange Glass")]
     public partial class OrangeGlassItem : BlockItem<OrangeGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassPink.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassPink.cs
@@ -92,7 +92,7 @@ namespace Eco.EM.Building.Windows
     [Serialized]
     [MaxStackSize(20)]
     [Currency]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [Weight(10000)]
     [LocDisplayName("Pink Glass")]
     public partial class PinkGlassItem : BlockItem<PinkGlassBlock>

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassPink.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassPink.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -93,6 +92,7 @@ namespace Eco.EM.Building.Windows
     [Serialized]
     [MaxStackSize(20)]
     [Currency]
+    [Tag("Coloured Glass")]
     [Weight(10000)]
     [LocDisplayName("Pink Glass")]
     public partial class PinkGlassItem : BlockItem<PinkGlassBlock>

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassPurple.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassPurple.cs
@@ -92,7 +92,7 @@ namespace Eco.EM.Building.Windows
     [Serialized]
     [MaxStackSize(20)]
     [Currency]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [Weight(10000)]
     [LocDisplayName("Purple Glass")]
     public partial class PurpleGlassItem : BlockItem<PurpleGlassBlock>

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassPurple.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassPurple.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -93,6 +92,7 @@ namespace Eco.EM.Building.Windows
     [Serialized]
     [MaxStackSize(20)]
     [Currency]
+    [Tag("Coloured Glass")]
     [Weight(10000)]
     [LocDisplayName("Purple Glass")]
     public partial class PurpleGlassItem : BlockItem<PurpleGlassBlock>

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassRed.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassRed.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -93,6 +92,7 @@ namespace Eco.EM.Building.Windows
     [Serialized]
     [MaxStackSize(20)]
     [Currency]
+    [Tag("Coloured Glass")]
     [Weight(10000)]
     [LocDisplayName("Red Glass")]
     public partial class RedGlassItem : BlockItem<RedGlassBlock>

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassRed.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassRed.cs
@@ -92,7 +92,7 @@ namespace Eco.EM.Building.Windows
     [Serialized]
     [MaxStackSize(20)]
     [Currency]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [Weight(10000)]
     [LocDisplayName("Red Glass")]
     public partial class RedGlassItem : BlockItem<RedGlassBlock>

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassWhite.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassWhite.cs
@@ -93,7 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [LocDisplayName("White Glass")]
     public partial class WhiteGlassItem : BlockItem<WhiteGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassWhite.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassWhite.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -94,6 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
+    [Tag("Coloured Glass")]
     [LocDisplayName("White Glass")]
     public partial class WhiteGlassItem : BlockItem<WhiteGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassYellow.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassYellow.cs
@@ -93,7 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
-    [Tag("Coloured Glass")]
+    [Tag("Colored Glass")]
     [LocDisplayName("Yellow Glass")]
     public partial class YellowGlassItem : BlockItem<YellowGlassBlock>
     {

--- a/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassYellow.cs
+++ b/9.6/EM Building/Eco.EM.Building.Windows/Glass/GlassYellow.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Eco.Core.Items;
+using Eco.EM.Framework.Extentsions;
+using Eco.EM.Framework.Resolvers;
 using Eco.Gameplay.Blocks;
 using Eco.Gameplay.Components;
 using Eco.Gameplay.Economy;
 using Eco.Gameplay.Items;
 using Eco.Gameplay.Objects;
 using Eco.Gameplay.Skills;
+using Eco.Mods.TechTree;
 using Eco.Shared.Localization;
 using Eco.Shared.Serialization;
 using Eco.World.Blocks;
-using Eco.Mods.TechTree;
-using Eco.EM.Framework.Resolvers;
-using Eco.EM.Framework;
+using System;
 using System.Linq;
-using Eco.EM.Framework.Extentsions;
 
 namespace Eco.EM.Building.Windows
 {
@@ -94,6 +93,7 @@ namespace Eco.EM.Building.Windows
     [MaxStackSize(20)]
     [Currency]
     [Weight(10000)]
+    [Tag("Coloured Glass")]
     [LocDisplayName("Yellow Glass")]
     public partial class YellowGlassItem : BlockItem<YellowGlassBlock>
     {


### PR DESCRIPTION
This is a simple change to add `Colored Glass` tag to the 11 glass pieces present in `Eco.Building.Windows` following the example of the tag existing for `Colored Bricks`.

This change lets mods target the objects without the need to add hard reference to the EM assemblies.